### PR TITLE
Handle spaces by quoting the command string instead of escaping

### DIFF
--- a/easy_extract/__init__.py
+++ b/easy_extract/__init__.py
@@ -1,5 +1,5 @@
 """easy_extract module"""
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 __license__ = 'GPL'
 
 __author__ = 'Fantomas42'

--- a/easy_extract/archive.py
+++ b/easy_extract/archive.py
@@ -1,7 +1,7 @@
 """Archive collection modules"""
 import os
 
-CHAR_TO_ESCAPE = (' ', '(', ')', '*', "'", '"', '&')
+CHAR_TO_ESCAPE = ('(', ')', '*', "'", '"', '&')
 
 
 class BaseFileCollection(object):

--- a/easy_extract/archives/hj_split.py
+++ b/easy_extract/archives/hj_split.py
@@ -18,11 +18,11 @@ class HJSplitArchive(Archive):
 
         print 'Extracting %s...' % new_filename
 
-        os.system('cat %s > %s' % (first_archive, new_filename))
+        os.system('cat "%s" > "%s"' % (first_archive, new_filename))
 
         for archive in self.archives[1:]:
             archive = self.get_command_filename(archive)
-            os.system('cat %s >> %s' % (archive, new_filename))
+            os.system('cat "%s" >> "%s"' % (archive, new_filename))
 
         return True
 

--- a/easy_extract/archives/media.py
+++ b/easy_extract/archives/media.py
@@ -18,7 +18,7 @@ class MediaArchive(Archive):
 
     def _extract(self):
         first_archive = self.get_command_filename(self.archives[0])
-        return not os.system('synoindex -a %s' % first_archive)
+        return not os.system('synoindex -a "%s"' % first_archive)
 
     def remove(self):
         pass

--- a/easy_extract/archives/rar.py
+++ b/easy_extract/archives/rar.py
@@ -20,4 +20,4 @@ class RarArchive(Archive):
         else:
             first_archive = self.get_command_filename(self.archives[0])
 
-        return not os.system('unrar e -o+ %s' % first_archive)
+        return not os.system('unrar e -o+ "%s"' % first_archive)

--- a/easy_extract/archives/seven_zip.py
+++ b/easy_extract/archives/seven_zip.py
@@ -19,4 +19,4 @@ class SevenZipArchive(Archive):
 
     def _extract(self):
         first_archive = self.get_command_filename(self.archives[0])
-        return not os.system('7z e -y %s' % first_archive)
+        return not os.system('7z e -y "%s"' % first_archive)

--- a/easy_extract/archives/xtm.py
+++ b/easy_extract/archives/xtm.py
@@ -19,7 +19,7 @@ class XtmArchive(Archive):
 
         print 'Extracting %s...' % new_filename
 
-        os.system('dd if="%s" skip=1 ibs=104 status=noxfer > "%s" 2>/dev/null'\
+        os.system('dd if="%s" skip=1 ibs=104 status=noxfer > "%s" 2>/dev/null'
                   % (first_archive, new_filename))
 
         for archive in self.archives[1:]:

--- a/easy_extract/archives/xtm.py
+++ b/easy_extract/archives/xtm.py
@@ -19,12 +19,12 @@ class XtmArchive(Archive):
 
         print 'Extracting %s...' % new_filename
 
-        os.system('dd if=%s skip=1 ibs=104 status=noxfer > %s 2>/dev/null' %
+        os.system('dd if="%s" skip=1 ibs=104 status=noxfer > "%s" 2>/dev/null' %
                   (first_archive, new_filename))
 
         for archive in self.archives[1:]:
             archive = self.get_command_filename(archive)
-            os.system('cat %s >> %s' % (archive, new_filename))
+            os.system('cat "%s" >> "%s"' % (archive, new_filename))
 
         return True
 

--- a/easy_extract/archives/xtm.py
+++ b/easy_extract/archives/xtm.py
@@ -19,8 +19,8 @@ class XtmArchive(Archive):
 
         print 'Extracting %s...' % new_filename
 
-        os.system('dd if="%s" skip=1 ibs=104 status=noxfer > "%s" 2>/dev/null' %
-                  (first_archive, new_filename))
+        os.system('dd if="%s" skip=1 ibs=104 status=noxfer > "%s" 2>/dev/null'\
+                  % (first_archive, new_filename))
 
         for archive in self.archives[1:]:
             archive = self.get_command_filename(archive)


### PR DESCRIPTION
This resolves issue #1 by quoting archive paths instead of converting them to "\\ ".